### PR TITLE
List ordering and display, duplicate grade error

### DIFF
--- a/backend/src/routes/adminRoutes/changeGrades.ts
+++ b/backend/src/routes/adminRoutes/changeGrades.ts
@@ -2,12 +2,7 @@ import "dotenv/config";
 import { Router } from "express";
 import { PrismaClient } from "../../generated/prisma-client/client.js";
 import { z } from "zod";
-import {
-  postGradeSchema,
-  personNrSchema,
-  studentSchema,
-  subjectSchema,
-} from "../../validators/valdation.js";
+import { postGradeSchema, personNrSchema } from "../../validators/valdation.js";
 
 const prisma = new PrismaClient();
 const router = Router();

--- a/backend/src/routes/adminRoutes/students.ts
+++ b/backend/src/routes/adminRoutes/students.ts
@@ -14,7 +14,9 @@ const router = Router();
 //get all students
 router.get("/", async (req, res) => {
   try {
-    const students = await prisma.student.findMany();
+    const students = await prisma.student.findMany({
+      orderBy: { lastName: "asc" },
+    });
     if (!students) {
       return res.json({ message: "No students registered." });
     }

--- a/backend/src/routes/adminRoutes/viewGrades.ts
+++ b/backend/src/routes/adminRoutes/viewGrades.ts
@@ -72,6 +72,7 @@ router.get("/:course/:year", async (req, res) => {
     const students = await prisma.student.findMany({
       where: { id: { in: studentIds }, year: validatedParams.data.year },
       select: { firstName: true, lastName: true, id: true, personNr: true },
+      orderBy: { lastName: "asc" },
     });
     const data = students.map((s) => {
       const g = grades.find((grade) => grade.studentId === s.id);

--- a/backend/src/validators/valdation.ts
+++ b/backend/src/validators/valdation.ts
@@ -75,3 +75,11 @@ export const subjectSchema = z.object({
   createdAt: dateSchema,
   updatedAt: dateSchema,
 });
+
+export const getGradeSchema = z.object({
+  grade: gradeScaleSchema,
+  year: yearSchema,
+  subject: z.string(),
+  level: z.string().toUpperCase(),
+  course: z.string(),
+});

--- a/backend/tests/integration/routes/studentRoute.integration.test.ts
+++ b/backend/tests/integration/routes/studentRoute.integration.test.ts
@@ -3,6 +3,7 @@ import supertest from "supertest";
 import express from "express";
 import studentRoute from "../../../src/routes/studentRoutes.js";
 import { PrismaClient } from "../../../src/generated/prisma-client/client.js";
+import { checkForDuplicateGrades } from "../../../src/routes/studentRoutes.js";
 
 const app = express();
 app.use(express.json());
@@ -93,4 +94,52 @@ describe("Student Route Integration Tests", () => {
     expect(res.status).toBe(404);
     expect(res.body.message).toBe("Student not found");
   });
+});
+
+test("Throw error if a student have duplicate grades", () => {
+  expect(() =>
+    checkForDuplicateGrades(
+      [
+        {
+          id: 280,
+          studentId: 12,
+          grade: "D",
+          year: 1,
+          subjectId: 22,
+          createdAt: new Date("2025-11-21T23:57:02.934Z"),
+          updatedAt: new Date("2025-11-21T23:57:02.934Z"),
+        },
+        {
+          id: 281,
+          studentId: 12,
+          grade: null,
+          year: 2,
+          subjectId: 23,
+          createdAt: new Date("2025-11-21T23:57:02.991Z"),
+          updatedAt: new Date("2025-11-21T23:57:02.991Z"),
+        },
+        {
+          id: 282,
+          studentId: 12,
+          grade: null,
+          year: 3,
+          subjectId: 24,
+          createdAt: new Date("2025-11-21T23:57:03.044Z"),
+          updatedAt: new Date("2025-11-21T23:57:03.044Z"),
+        },
+        {
+          id: 282,
+          studentId: 12,
+          grade: null,
+          year: 3,
+          subjectId: 24,
+          createdAt: new Date("2025-11-21T23:57:03.044Z"),
+          updatedAt: new Date("2025-11-21T23:57:03.044Z"),
+        },
+      ],
+      "Laura Croft"
+    )
+  ).toThrowError(
+    "Duplicate grade detected for student Laura Croft, subjectId=24"
+  );
 });

--- a/frontend/src/components/AdminRegisterGrades.tsx
+++ b/frontend/src/components/AdminRegisterGrades.tsx
@@ -133,7 +133,7 @@ export default function AdminRegisterGrades() {
       });
 
       toast.success("Grade added!");
-      window.location.reload();
+      //window.location.reload();
     } catch {
       toast.error("Error adding grade!");
     }
@@ -148,24 +148,15 @@ export default function AdminRegisterGrades() {
 
     try {
       const [name, level] = selectedCourse.split(" ");
-      const res = await fetch(
-        `http://localhost:5001/admin/grades/${grade.gradeId}`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            name,
-            level,
-            grade: grade.grade,
-            year: parseInt(selectedYear),
-          }),
-        }
-      );
-
-      if (!res.ok) throw new Error();
+      await api.put(`/admin/grades/${grade.gradeId}`, {
+        name,
+        level,
+        grade: grade.grade,
+        year: parseInt(selectedYear),
+      });
 
       toast.success("Grade updated!");
-      window.location.reload();
+      //window.location.reload();
     } catch {
       toast.error("Error updating grade!");
     }

--- a/frontend/src/components/StudentGrades.tsx
+++ b/frontend/src/components/StudentGrades.tsx
@@ -52,9 +52,8 @@ export default function StudentGrades() {
           course: g.course ?? g.subject, // optional normalization
         })
       );
-
       const uniqueSubjects = Array.from(
-        new Set(subjectwithGrades.map((g) => g.subject || g.course))
+        new Set(subjectwithGrades.map((g) => g.course || g.subject))
       ).filter((s): s is string => Boolean(s));
 
       setSubjects(uniqueSubjects);
@@ -138,7 +137,7 @@ export default function StudentGrades() {
               {selectedYear === "All" && (
                 <th className="border px-4 py-2">Year</th>
               )}
-              <th className="border px-4 py-2">Level</th>
+              {/* <th className="border px-4 py-2">Level</th> */}
             </tr>
           </thead>
           <tbody>
@@ -154,12 +153,12 @@ export default function StudentGrades() {
             ) : (
               filteredGrades.map((g, i) => (
                 <tr key={i} className={i % 2 === 0 ? "bg-white" : "bg-gray-50"}>
-                  <td className="border px-4 py-2">{g.subject || g.course}</td>
+                  <td className="border px-4 py-2">{g.course || g.subject}</td>
                   <td className="border px-4 py-2">{g.grade}</td>
                   {selectedYear === "All" && (
                     <td className="border px-4 py-2">{g.year || "-"}</td>
                   )}
-                  <td className="border px-4 py-2">{g.level || "-"}</td>
+                  {/* <td className="border px-4 py-2">{g.level || "-"}</td> */}
                 </tr>
               ))
             )}


### PR DESCRIPTION
fixed the put-grades route to work, sorted/ordered list of students/subjects, merged grade+level to one row in the studentGrade view, made error checking for duplicate grades on the same student.